### PR TITLE
add devhub as reference project

### DIFF
--- a/mobile.md
+++ b/mobile.md
@@ -1,4 +1,4 @@
 # Mobile
 ### React Native
 #### Reference Projects
-https://github.com/smashingboxes/devhub
+https://github.com/smashingboxes/devhub/tree/v0.96.0


### PR DESCRIPTION
According to Matt Wood devhub "was our model for building Transenterix and the strongest community example I know of for RN + RNWeb all in one project".

Since devhub has gone closed-source, I forked the latest release of the original repo (in case the author deletes the repo) and added a link to our fork to the mobile engineering guide.
