### PR TITLE
add devops guide with a best practice of tagging resources

### DIFF
--- a/devops.md
+++ b/devops.md
@@ -1,3 +1,3 @@
 # DevOps
 ## Best Practices
-- Every resource you create (e.g. an EC2 instance) should have two tags that identify what project (e.g. `my-project`) and environment (`development` | `staging` | `qa` | `production`) the resource belongs to.
+- Every resource you create (e.g. an EC2 instance) should have two tags that identify what project (e.g. `my-project`) and environment (`development` | `staging` | `qa` | `demo` | `production`) the resource belongs to.


### PR DESCRIPTION
The current situation of our AWS account is that there are hundreds of AWS resources that don't have a name or tag. We are hesitant to destroy them since we don't know if some of them might be used by an active project.

I propose to make it an official best practice that every AWS resource we create should have a tag that identifies the project and the environment the resource belongs to. The same would apply for DigitalOcean, Heroku etc.

The benefit would be that anyone who's trying to remove unused resources (that we pay for!) can do so easily, without having to worry about breaking something. It would also make it a lot easier to use the respective dashboard if you could filter and sort resources by project and environment.