### PR TITLE
add best practice for python imports

### DIFF
--- a/backend.md
+++ b/backend.md
@@ -6,7 +6,7 @@
 
 #### Imports
 
-The `main()` function that starts the application should reside at the project's top-level folder so you can use "absolute" imports.
+The file containing the `main()` function that starts the application should reside at the project's top-level folder so you can use "absolute" imports.
 
 ##### Example
 ```


### PR DESCRIPTION
Python imports are very confusing and answers on StackOverflow usually suggest dirty hacks instead of pointing to the only reasonable pattern of "absolute" imports, as used by frameworks like Django and Flask.
