### PR TITLE
add Import Cost VS Code extension to frontend tooling

### DIFF
--- a/frontend.md
+++ b/frontend.md
@@ -1,2 +1,11 @@
 # Frontend
 
+## Tooling
+
+### VS Code Extensions
+
+#### Import Cost
+Import Cost displays the size of the imported package inline in the editor.
+
+##### Installation
+Search the VS Code extensions for `Import Cost` and click `Install`.


### PR DESCRIPTION
 It is always better to only import dependencies you actually need. JavaScript lets you do that, but it's easy to forget to do so. This VS Code extension makes you aware of how large imported dependencies are.